### PR TITLE
fixes #189

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,9 +1334,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.2"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826f989c0f374733af6c286f4822f293bc738def07e2782dc1cbb899960a504a"
+checksum = "f50845f68d5c693aac7d72a25415ddd21cb8182c04eafe447b73af55a05f9e1b"
 dependencies = [
  "indexmap",
  "itoa 1.0.1",
@@ -1731,9 +1731,9 @@ checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dc1c637311091be28e5d462c07db78081e5828da80ba22605c81c4ad6f7f813"
+checksum = "931179334a56395bcf64ba5e0ff56781381c1a5832178280c7d7f91d1679aeb0"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ log = "0.4"
 env_logger = "0.9.0"
 yaml-rust = "0.4"
 serde = { version = "1.0", features = ["derive","rc"] }
-serde_yaml = "0.9.2"
+serde_yaml = "0.9.9"
 serde_json = "1.0"
 clap = "3.2"
 futures = "0.3.21"

--- a/src/access_log.rs
+++ b/src/access_log.rs
@@ -75,6 +75,7 @@ impl Formater for ScriptFormater {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AccessLog {
     path: PathBuf,
+    #[serde(with = "serde_yaml::with::singleton_map_recursive")]
     format: Format,
     #[serde(skip)]
     tx: Option<Sender<Option<Arc<ContextProps>>>>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -37,3 +37,13 @@ impl Default for Timeouts {
         Timeouts { idle: 600 }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[tokio::test]
+    async fn test_load() {
+        use super::*;
+        let cfg = Config::load("config.yaml").await;
+        assert!(cfg.is_ok());
+    }
+}

--- a/src/connectors/loadbalance.rs
+++ b/src/connectors/loadbalance.rs
@@ -25,7 +25,11 @@ pub struct LoadBalanceConnector {
     name: String,
     connectors: Vec<String>,
 
-    #[serde(alias = "algo", default)]
+    #[serde(
+        alias = "algo",
+        default,
+        with = "serde_yaml::with::singleton_map_recursive"
+    )]
     algorithm: Algorithm,
 
     // for RoundRobin selection,


### PR DESCRIPTION
serde_yaml uses yaml tags for enums by default after v0.9.0.
so we have to add serde_yaml::with::singleton_map_recursive
to maintain backward compatibility