### PR TITLE
Refactor/simplify milu tests

### DIFF
--- a/milu/src/parser/tests.rs
+++ b/milu/src/parser/tests.rs
@@ -192,7 +192,7 @@ fn parse_function_definition_no_args() {
         arg_idents: vec![],
         body: int!(42),
     })));
-    let expected_expr_in_scope = call!(id!("get_num"));
+    let expected_expr_in_scope = call!(vec![id!("get_num")]);
     let expected_value = scope!(expected_vars, expected_expr_in_scope);
     assert_ast(input, expected_value);
 }

--- a/milu/src/script/mod.rs
+++ b/milu/src/script/mod.rs
@@ -7,9 +7,9 @@ pub mod types;
 pub mod value;
 
 #[cfg(test)]
-mod tests; // tests.rs is now a sibling module
-#[cfg(test)]
 pub mod test_utils;
+#[cfg(test)]
+mod tests; // tests.rs is now a sibling module
 
 // Re-export key items to be available under `crate::script::*`
 pub use context::*;

--- a/milu/src/script/test_utils.rs
+++ b/milu/src/script/test_utils.rs
@@ -3,7 +3,6 @@
 use crate::script::{
     Accessible, Callable, Evaluatable, Indexable, NativeObject, ScriptContextRef, Type, Value,
 };
-use async_trait::async_trait;
 use easy_error::{bail, err_msg, Error};
 // Arc is not directly used in the moved code blocks but might be relevant for how these objects are used elsewhere.
 // For now, let's only include what's directly necessary for these implementations. ScriptContextRef handles Arc internally.
@@ -55,8 +54,7 @@ impl Indexable for (String, u32) {
             .0
             .chars()
             .nth(index as usize)
-            .ok_or_else(|| err_msg("index out of range"))?
-            as i64;
+            .ok_or_else(|| err_msg("index out of range"))? as i64;
         Ok(n_char_val.into())
     }
 }


### PR DESCRIPTION
This commit applies several refactorings to the milu tests to reduce
code duplication and improve maintainability.

Key changes:

- In `milu/src/script/tests.rs`:
    - Introduced an `assert_eval_and_type!` macro to combine common
      value and type assertions, reducing boilerplate in tests.
    - Added helper functions `create_context_with_native_object` and
      `create_context_with_variable` to streamline `ScriptContext` setup
      for tests requiring specific contexts.
    - Corrected the expected type in `eval_mutually_recursive_functions`
      test from Integer to Boolean.

- Moved test-specific `NativeObject` implementations (for `(String, u32)`,
  `TestNativeSimple`, `TestNativeFailingAccess`, `TestNativeFailingCall`)
  from `milu/src/script/tests.rs` to a new `milu/src/script/test_utils.rs`
  module. This module is conditionally compiled for tests.

- In `milu/src/parser/tests.rs`:
    - Corrected `call!` macro usage in `parse_function_definition_no_args`
      for consistency.

These changes aim to make the test suite cleaner, more readable, and
easier to extend in the future.