### PR TITLE
Add HTTP authentication support for connectors and listeners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1777,6 +1777,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "base64",
  "bytes",
  "chashmap-async",
  "cidr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ axum = { version = "0.8", optional = true }
 tower = { version = "0.5", optional = true }
 tower-http = { version = "0.6", optional = true, features = ["add-extension","fs","set-header","trace"] }
 prometheus = {version = "0.14", optional = true, features = ["process"] }
+base64 = "0.22.1"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 nix = { version = "0.30" , features = ["socket","net","zerocopy","uio","fs"] }

--- a/src/connectors/quic.rs
+++ b/src/connectors/quic.rs
@@ -154,7 +154,7 @@ impl QuicConnector {
             "quic-datagrams"
         };
         let frames = |id| create_quic_frames(conn, id, sessions);
-        http_forward_proxy_connect(server, ctx, local, remote, channel, frames, false).await?;
+        http_forward_proxy_connect(server, ctx, local, remote, channel, frames, false, None).await?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

This PR implements HTTP Basic Authentication support for both HTTP connectors (upstream proxy authentication) and HTTP listeners (client authentication), providing comprehensive authentication capabilities for the redproxy-rs proxy server.

### Key Features

#### 🔗 HTTP Connectors (Outbound Authentication)
- **New `HttpAuthData` struct** with username and password fields
- **Updated `HttpConnectorConfig`** to include optional `auth` field  
- **Enhanced `http_forward_proxy_connect()`** to add `Proxy-Authorization: Basic <credentials>` header
- **Full support** for both CONNECT tunneling and HTTP forward proxy modes with authentication

#### 🛡️ HTTP Listeners (Inbound Authentication)
- **Updated `HttpListenerConfig`** to include `AuthData` field (following existing SOCKS pattern)
- **Enhanced `http_forward_proxy_handshake()`** to parse and validate `Proxy-Authorization`/`Authorization` headers
- **Integration** with existing `AuthData` validation system (supports both static users and command-based auth)
- **Proper error handling** with 407 Proxy Authentication Required responses

#### ⚡ QUIC Integration  
- **Updated QUIC connectors** to pass auth parameter (None for backward compatibility)
- **Updated QUIC listeners** to support authentication using the same `AuthData` system

### Technical Implementation

- **HTTP Basic Authentication**: Standard `Basic <base64(username:password)>` encoding
- **Robust base64 handling**: Proper encoding/decoding with validation and error handling
- **Backward compatibility**: All auth fields are optional, no breaking changes to existing configs
- **Comprehensive testing**: Added tests for authentication functionality and base64 operations

### Configuration Examples

**HTTP Connector with Authentication:**
```yaml
connectors:
  - name: upstream-proxy
    type: http
    server: proxy.example.com
    port: 8080
    auth:
      username: myuser
      password: mypass
```

**HTTP Listener with Authentication:**
```yaml  
listeners:
  - name: http-proxy
    type: http
    bind: 0.0.0.0:8080
    auth:
      required: true
      users:
        - username: client1
          password: secret123
```

## Test Plan

- [x] All existing tests pass (71/71)
- [x] New authentication tests added and passing
- [x] Base64 encoding/decoding tests with edge cases
- [x] HTTP connector authentication integration test
- [x] Release build verification completed
- [x] Backward compatibility verified - existing configs work unchanged

## Dependencies

- Added `base64` crate for proper credential encoding

🤖 Generated with [Claude Code](https://claude.ai/code)