### PR TITLE
🔒 [security fix] Fix insecure SSH server verification default

### DIFF
--- a/src/connectors/ssh.rs
+++ b/src/connectors/ssh.rs
@@ -23,7 +23,6 @@ pub struct SshConnectorConfig {
     pub port: u16,
     pub username: String,
     pub auth: SshAuth,
-    #[serde(default)]
     pub server_key_verification: ServerKeyVerification,
     #[serde(default = "default_connector_timeout")]
     pub inactivity_timeout_secs: u64,
@@ -46,29 +45,11 @@ pub enum SshAuth {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "type")]
-#[derive(Default)]
 pub enum ServerKeyVerification {
     #[serde(rename = "fingerprint")]
     Fingerprint { fingerprint: String },
     #[serde(rename = "insecureAcceptAny")]
-    #[default]
     InsecureAcceptAny,
-}
-
-impl Default for SshConnectorConfig {
-    fn default() -> Self {
-        Self {
-            name: String::new(),
-            server: String::new(),
-            port: 22,
-            username: String::new(),
-            auth: SshAuth::Password {
-                password: String::new(),
-            },
-            server_key_verification: ServerKeyVerification::default(),
-            inactivity_timeout_secs: default_connector_timeout(),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -249,6 +230,8 @@ username: testuser
 auth:
   type: password
   password: testpass
+serverKeyVerification:
+  type: insecureAcceptAny
 "#;
         let value: Value = serde_yaml_ng::from_str(yaml).expect("Failed to parse test YAML");
         let connector = from_value(&value).expect("Failed to deserialize SSH connector config");
@@ -267,6 +250,8 @@ auth:
   type: privateKey
   path: /path/to/key
   passphrase: keypass
+serverKeyVerification:
+  type: insecureAcceptAny
 "#;
         let value: Value = serde_yaml_ng::from_str(yaml).expect("Failed to parse test YAML");
         let connector = from_value(&value).expect("Failed to deserialize SSH connector config");
@@ -284,6 +269,8 @@ username: keyuser
 auth:
   type: privateKey
   path: /path/to/key
+serverKeyVerification:
+  type: insecureAcceptAny
 "#;
         let value: Value = serde_yaml_ng::from_str(yaml).expect("Failed to parse test YAML");
         let _connector = from_value(&value).expect("Failed to deserialize SSH connector config");
@@ -317,6 +304,8 @@ username: testuser
 auth:
   type: password
   password: testpass
+serverKeyVerification:
+  type: insecureAcceptAny
 "#;
         let value: Value = serde_yaml_ng::from_str(yaml).expect("Failed to parse test YAML");
         let result = from_value(&value);
@@ -334,6 +323,8 @@ username: testuser
 auth:
   type: password
   password: testpass
+serverKeyVerification:
+  type: insecureAcceptAny
 "#;
         let value: Value = serde_yaml_ng::from_str(yaml).expect("Failed to parse test YAML");
         let _connector = from_value(&value).expect("Failed to deserialize SSH connector config");

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -120,16 +120,15 @@ impl Rule {
             rules_metrics().execute_time.start_timer()
         };
         let t = Instant::now();
-        let ret = if self.filter.is_none() {
-            true
-        } else {
-            match self.filter.as_ref().unwrap().evaluate(request).await {
+        let ret = match &self.filter {
+            None => true,
+            Some(f) => match f.evaluate(request).await {
                 Ok(b) => b,
                 Err(e) => {
                     trace!("error evaluating filter: {:?}", e);
                     false
                 }
-            }
+            },
         };
         let t = t.elapsed().as_nanos() as u64;
         #[cfg(feature = "metrics")]

--- a/tests/comprehensive/scripts/generate_matrix_config.py
+++ b/tests/comprehensive/scripts/generate_matrix_config.py
@@ -148,6 +148,9 @@ class MatrixGenerator:
                     "auth": {
                         "type": "password",
                         "password": "proxy123"
+                    },
+                    "serverKeyVerification": {
+                        "type": "insecureAcceptAny"
                     }
                 }
             ),

--- a/tests/ssh_security.rs
+++ b/tests/ssh_security.rs
@@ -1,0 +1,61 @@
+use redproxy_rs::connectors::ssh::{SshConnectorConfig, ServerKeyVerification};
+use serde_yaml_ng::Value;
+
+#[test]
+fn test_missing_verification_fails() {
+    let yaml = r#"
+name: test-ssh
+type: ssh
+server: ssh.example.com
+port: 22
+username: testuser
+auth:
+  type: password
+  password: testpass
+"#;
+    let result: Result<SshConnectorConfig, _> = serde_yaml_ng::from_str(yaml);
+    assert!(result.is_err(), "Deserialization should fail when serverKeyVerification is missing");
+    let err = result.err().unwrap().to_string();
+    assert!(err.contains("missing field `serverKeyVerification`"), "Error message should mention missing field: {}", err);
+}
+
+#[test]
+fn test_explicit_insecure_verification_succeeds() {
+    let yaml = r#"
+name: test-ssh
+type: ssh
+server: ssh.example.com
+port: 22
+username: testuser
+auth:
+  type: password
+  password: testpass
+serverKeyVerification:
+  type: insecureAcceptAny
+"#;
+    let config: SshConnectorConfig = serde_yaml_ng::from_str(yaml).expect("Deserialization should succeed with explicit insecureAcceptAny");
+    assert!(matches!(config.server_key_verification, ServerKeyVerification::InsecureAcceptAny));
+}
+
+#[test]
+fn test_explicit_fingerprint_verification_succeeds() {
+    let yaml = r#"
+name: test-ssh
+type: ssh
+server: ssh.example.com
+port: 22
+username: testuser
+auth:
+  type: password
+  password: testpass
+serverKeyVerification:
+  type: fingerprint
+  fingerprint: "SHA256:abcd"
+"#;
+    let config: SshConnectorConfig = serde_yaml_ng::from_str(yaml).expect("Deserialization should succeed with explicit fingerprint");
+    if let ServerKeyVerification::Fingerprint { fingerprint } = config.server_key_verification {
+        assert_eq!(fingerprint, "SHA256:abcd");
+    } else {
+        panic!("Expected Fingerprint variant");
+    }
+}

--- a/tests/ssh_security.rs
+++ b/tests/ssh_security.rs
@@ -1,4 +1,4 @@
-use redproxy_rs::connectors::ssh::{SshConnectorConfig, ServerKeyVerification};
+use redproxy_rs::connectors::ssh::{ServerKeyVerification, SshConnectorConfig};
 use serde_yaml_ng::Value;
 
 #[test]
@@ -14,9 +14,16 @@ auth:
   password: testpass
 "#;
     let result: Result<SshConnectorConfig, _> = serde_yaml_ng::from_str(yaml);
-    assert!(result.is_err(), "Deserialization should fail when serverKeyVerification is missing");
+    assert!(
+        result.is_err(),
+        "Deserialization should fail when serverKeyVerification is missing"
+    );
     let err = result.err().unwrap().to_string();
-    assert!(err.contains("missing field `serverKeyVerification`"), "Error message should mention missing field: {}", err);
+    assert!(
+        err.contains("missing field `serverKeyVerification`"),
+        "Error message should mention missing field: {}",
+        err
+    );
 }
 
 #[test]
@@ -33,8 +40,12 @@ auth:
 serverKeyVerification:
   type: insecureAcceptAny
 "#;
-    let config: SshConnectorConfig = serde_yaml_ng::from_str(yaml).expect("Deserialization should succeed with explicit insecureAcceptAny");
-    assert!(matches!(config.server_key_verification, ServerKeyVerification::InsecureAcceptAny));
+    let config: SshConnectorConfig = serde_yaml_ng::from_str(yaml)
+        .expect("Deserialization should succeed with explicit insecureAcceptAny");
+    assert!(matches!(
+        config.server_key_verification,
+        ServerKeyVerification::InsecureAcceptAny
+    ));
 }
 
 #[test]
@@ -52,7 +63,8 @@ serverKeyVerification:
   type: fingerprint
   fingerprint: "SHA256:abcd"
 "#;
-    let config: SshConnectorConfig = serde_yaml_ng::from_str(yaml).expect("Deserialization should succeed with explicit fingerprint");
+    let config: SshConnectorConfig = serde_yaml_ng::from_str(yaml)
+        .expect("Deserialization should succeed with explicit fingerprint");
     if let ServerKeyVerification::Fingerprint { fingerprint } = config.server_key_verification {
         assert_eq!(fingerprint, "SHA256:abcd");
     } else {


### PR DESCRIPTION
This PR fixes a security vulnerability where the SSH connector would silently default to an insecure state (accepting any server key) if the configuration was omitted.

🎯 **What:** The vulnerability fixed is the insecure default for SSH host key verification.
⚠️ **Risk:** If left unfixed, attackers could perform Man-In-The-Middle (MITM) attacks on SSH connections established through the proxy.
🛡️ **Solution:** The fix makes `serverKeyVerification` a mandatory field in the SSH connector configuration. Users must now explicitly provide a host key fingerprint or explicitly opt-in to insecure behavior. This follows the "Secure by Default" principle.

---
*PR created automatically by Jules for task [3122378215122098665](https://jules.google.com/task/3122378215122098665) started by @bearice*